### PR TITLE
Resolve Call to receive_sequence() hangs In PocketFT8XcvrFW. No furth…

### DIFF
--- a/PocketFT8XcvrFW/traffic_manager.cpp
+++ b/PocketFT8XcvrFW/traffic_manager.cpp
@@ -4,7 +4,7 @@
 #include "decode_ft8.h"
 #include "gen_ft8.h"
 #include "button.h"
-#define PTT_Pin 13
+#define PTT_Pin 14            //For Teensy 4.1
 #include <SI4735.h>
 
 #define FT8_TONE_SPACING        625


### PR DESCRIPTION
PTT_PIN was incorrectly configured for Teensy 4.1 in traffic_manager.cpp.  It was D13 in Charlie's original Teensy 3.6 Pocket FT8 code but had to move to D14 for Teensy 4.1