### PR TITLE
Implement FW support for PIN_RCV

### DIFF
--- a/PocketFT8XcvrFW/pins.h
+++ b/PocketFT8XcvrFW/pins.h
@@ -1,0 +1,46 @@
+/*
+**
+** NAME
+**  pins.h --- Define usage of all GPIO pins in this one place
+**
+** NOTES
+**  If you change processors, displays, etc, you may need to reevaluate the GPIO pin assignments
+**
+**  The V2.0 boards control the RCV and XMT signals using firmware thru PIN_RCV and PIN_PTT.  
+**  This firmware implementation is compatible with both V1.X and V2.0 boards.
+**
+** HISTORY
+**  10/08/2024 Teensy 4.1 pin assignments by KQ7B
+**
+**/
+
+//The Adafruit 480x320 display pins
+#define PIN_CS    10
+#define PIN_DC    9
+#define PIN_RST   8
+#define PIN_MOSI  11
+#define PIN_DCLK  13          //Teensy 4.1
+#define PIN_MISO  12
+
+//I2C pins
+#define PIN_SCL   19
+#define PIN_SDA   18
+
+//SI4735 pins
+#define PIN_RESET 20
+
+//Transmit/Receive pins
+#define PIN_PTT   14            //Teensy 4.1
+#define PIN_RCV   15            //FW implementation of ~PTT (i.e. RECV) in V2.0 boards
+
+//Adafruit resistive touchscreen pins
+#define PIN_YP 38               // must be an analog pin, use "An" notation!
+#define PIN_XM 37               // must be an analog pin, use "An" notation!
+#define PIN_YM 36               // can be a digital pin
+#define PIN_XP 39               // can be a digital pin
+
+//GPS pins
+#define PIN_GPSTX 0             //TX data from GPS
+#define PIN_GPSRX 1             //RX data from GPS
+
+

--- a/PocketFT8XcvrFW/traffic_manager.cpp
+++ b/PocketFT8XcvrFW/traffic_manager.cpp
@@ -5,10 +5,10 @@
 #include "decode_ft8.h"
 #include "gen_ft8.h"
 #include "button.h"
-#define PTT_Pin 14            //For Teensy 4.1
+#include "pins.h"
 #include <SI4735.h>
 
-#define FT8_TONE_SPACING        625
+#define FT8_TONE_SPACING 625
 
 extern Si5351 si5351;
 extern SI4735 si4735;
@@ -26,104 +26,116 @@ extern int offset_freq;
 
 uint64_t F_Long, F_FT8, F_Offset;
 
-   void transmit_sequence(void){
-      set_Xmit_Freq();
-      si5351.set_freq(F_Long, SI5351_CLK0);
-      si4735.setVolume(35);
-      si5351.drive_strength(SI5351_CLK0, SI5351_DRIVE_8MA); // Set for max power if desired
-      si5351.output_enable(SI5351_CLK0, 1);
-      pinMode(PTT_Pin, OUTPUT); 
-      digitalWrite(PTT_Pin, HIGH);   
-   }
+void transmit_sequence(void) {
 
-      void receive_sequence(void){
-       si5351.output_enable(SI5351_CLK0, 0);
-       pinMode(PTT_Pin, OUTPUT);
-       digitalWrite(PTT_Pin, LOW);
-       si4735.setVolume(50);
-       clear_FT8_message();   
+  //Turn off the receiver (req'd for V2.0 boards)
+  pinMode(PIN_RCV, OUTPUT);
+  digitalWrite(PIN_RCV, LOW);
 
-   }
+  //Turn on the transmitter
+  set_Xmit_Freq();
+  si5351.set_freq(F_Long, SI5351_CLK0);
+  si4735.setVolume(35);
+  si5351.drive_strength(SI5351_CLK0, SI5351_DRIVE_8MA);  // Set for max power if desired
+  si5351.output_enable(SI5351_CLK0, 1);
+  pinMode(PIN_PTT, OUTPUT);
+  digitalWrite(PIN_PTT, HIGH);
+}
 
-   
-   void tune_On_sequence(void){
-      set_Xmit_Freq();
-      si5351.set_freq(F_Long, SI5351_CLK0);
-      si4735.setVolume(35);
-      si5351.output_enable(SI5351_CLK0, 1);
-      pinMode(PTT_Pin, OUTPUT); 
-      digitalWrite(PTT_Pin, HIGH); 
-   }
+void receive_sequence(void) {
 
-      void tune_Off_sequence(void){
-       si5351.output_enable(SI5351_CLK0, 0); 
-       pinMode(PTT_Pin, OUTPUT);
-       digitalWrite(PTT_Pin, LOW); 
-       si4735.setVolume(50);
-   }
+  //Turn off the transmitter
+  si5351.output_enable(SI5351_CLK0, 0);
+  pinMode(PIN_PTT, OUTPUT);
+  digitalWrite(PIN_PTT, LOW);
+
+  //Turn on the receiver (Req'd for V2.0 boards)
+  pinMode(PIN_RCV, OUTPUT);
+  digitalWrite(PIN_RCV, HIGH);
+  si4735.setVolume(50);
+  clear_FT8_message();
+}
 
 
-   void  set_Xmit_Freq(){
+void tune_On_sequence(void) {
+  set_Xmit_Freq();
+  si5351.set_freq(F_Long, SI5351_CLK0);
+  si4735.setVolume(35);
+  si5351.output_enable(SI5351_CLK0, 1);
+  pinMode(PIN_PTT, OUTPUT);
+  digitalWrite(PIN_PTT, HIGH);
+}
 
-     // display_value(400, 320, ( int ) cursor_freq);
-     // display_value(400, 360,  offset_freq);
-      F_Long = (uint64_t) ((currentFrequency * 1000 + cursor_freq + offset_freq) * 100);
-      //F_Long = (uint64_t) ((currentFrequency * 1000 + cursor_freq ) * 100);
-      si5351.set_freq(F_Long, SI5351_CLK0);
+void tune_Off_sequence(void) {
+  si5351.output_enable(SI5351_CLK0, 0);
+  pinMode(PIN_PTT, OUTPUT);
+  digitalWrite(PIN_PTT, LOW);
+  si4735.setVolume(50);
+}
+
+
+void set_Xmit_Freq() {
+
+  // display_value(400, 320, ( int ) cursor_freq);
+  // display_value(400, 360,  offset_freq);
+  F_Long = (uint64_t)((currentFrequency * 1000 + cursor_freq + offset_freq) * 100);
+  //F_Long = (uint64_t) ((currentFrequency * 1000 + cursor_freq ) * 100);
+  si5351.set_freq(F_Long, SI5351_CLK0);
 }
 
 
 
-    void set_FT8_Tone( uint8_t ft8_tone) {
-          F_FT8 =  F_Long + uint64_t(ft8_tone) * FT8_TONE_SPACING;
-          si5351.set_freq(F_FT8, SI5351_CLK0);
-    }
+void set_FT8_Tone(uint8_t ft8_tone) {
+  F_FT8 = F_Long + uint64_t(ft8_tone) * FT8_TONE_SPACING;
+  si5351.set_freq(F_FT8, SI5351_CLK0);
+}
 
 
-    void setup_to_transmit_on_next_DSP_Flag(void){
-        ft8_xmit_counter = 0;
-        transmit_sequence();
-        set_Xmit_Freq();
-        xmit_flag = 1;
+void setup_to_transmit_on_next_DSP_Flag(void) {
+  ft8_xmit_counter = 0;
+  transmit_sequence();
+  set_Xmit_Freq();
+  xmit_flag = 1;
+}
 
-    }
 
+void service_CQ(void) {
 
-    void service_CQ (void) {
+  DTRACE();
 
-      DTRACE();
+  int receive_index;
 
-      int receive_index;
+  DPRINTF("Beacon_State=%u\n", Beacon_State);
 
-      DPRINTF("Beacon_State=%u\n",Beacon_State);
+  switch (Beacon_State) {
 
-      switch (Beacon_State) {
-
-      case 0: Beacon_State = 1;//Listen 
+    case 0:
+      Beacon_State = 1;  //Listen
       break;
 
-      case 1: receive_index = Check_Calling_Stations(num_decoded_msg);
-      
-              if(receive_index >= 0) {
-              display_selected_call(receive_index);
-              set_message(2); // send RSL
-              }
-              else
-              set_message(0); // send CQ
-              Transmit_Armned = 1;
-              Beacon_State = 2;
-       
+    case 1:
+      receive_index = Check_Calling_Stations(num_decoded_msg);
+
+      if (receive_index >= 0) {
+        display_selected_call(receive_index);
+        set_message(2);  // send RSL
+      } else
+        set_message(0);  // send CQ
+      Transmit_Armned = 1;
+      Beacon_State = 2;
+
       break;
 
-      case 2: receive_index = Check_Calling_Stations(num_decoded_msg);
-      
-              if(receive_index >= 0) {
-              display_selected_call(receive_index);
-              set_message(3); // send 73
-              Transmit_Armned = 1;
-              }
+    case 2:
+      receive_index = Check_Calling_Stations(num_decoded_msg);
 
-              Beacon_State = 0;
+      if (receive_index >= 0) {
+        display_selected_call(receive_index);
+        set_message(3);  // send 73
+        Transmit_Armned = 1;
+      }
+
+      Beacon_State = 0;
       break;
 
       /*
@@ -138,10 +150,5 @@ uint64_t F_Long, F_FT8, F_Offset;
        
       break;
       */
-
-        
-      }
-      
-    }
-
-
+  }
+}


### PR DESCRIPTION
The V2.X boards require firmware implementation of the RCV and XMT signals; V1.X boards did this in hardware.  This firmware implementation is compatible with both V1.X and V2.X boards.

All GPIO pins are now defined in a single location, pins.h